### PR TITLE
Search functionality

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,7 @@ var rootCmd = &cobra.Command{
 		// Context and errgroup used to manage routines
 		eg, ctx := errgroup.WithContext(context.Background())
 		dataChannel := make(chan api.AssetData)
+		searchChannel := make(chan []api.CoinSearchDetails)
 
 		// Flag to determine if data must be sent when viewing per coin prices
 		sendData := true
@@ -59,7 +60,7 @@ var rootCmd = &cobra.Command{
 
 		// Display UI for overall coins
 		eg.Go(func() error {
-			return allcoin.DisplayAllCoins(ctx, dataChannel, &sendData)
+			return allcoin.DisplayAllCoins(ctx, dataChannel, searchChannel, &sendData)
 		})
 
 		if err := eg.Wait(); err != nil {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -20,14 +20,16 @@ import geckoTypes "github.com/superoo7/go-gecko/v3/types"
 
 // CoinData Holds data pertaining to a single coin.
 // This is used to serve per coin details.
-// It additionally holds a map of favourite coins.
+// It additionally holds a map of favourite coins
+// and a list of details about searched coins
 type CoinData struct {
-	Type         string
-	PriceHistory []float64
-	MinPrice     float64
-	MaxPrice     float64
-	Details      CoinDetails
-	Favourites   map[string]float64
+	Type              string
+	PriceHistory      []float64
+	MinPrice          float64
+	MaxPrice          float64
+	Details           CoinDetails
+	Favourites        map[string]float64
+	CoinSearchDetails []CoinSearchDetails
 }
 
 // CoinDetails holds information about a coin
@@ -93,3 +95,10 @@ type CoinID struct {
 
 // CoinIDMap maps a symbol to it's respective ID
 type CoinIDMap map[string]CoinID
+
+// CoinSearchDetails represents some basic details about a searched coin
+type CoinSearchDetails struct {
+	Name   string
+	Price  float64
+	Symbol string
+}

--- a/pkg/widgets/search.go
+++ b/pkg/widgets/search.go
@@ -32,7 +32,7 @@ type SearchMenu struct {
 	*Table
 	IsFull             bool
 	SymbolDoesNotExist bool
-	SearchList         [][]string
+	SearchData         [][]string
 }
 
 // NewSearchMenu is a constructor for the SearchMenu type
@@ -45,25 +45,26 @@ func NewSearchMenu() *SearchMenu {
 // Reset resets a search menu to its default values
 func (search *SearchMenu) Reset() {
 	search.SearchString = ""
-	search.SearchList = [][]string{}
+	search.SearchData = [][]string{}
 	search.IsFull = true
 	search.SymbolDoesNotExist = false
-	search.Table.SelectedRow = 0
+	search.SelectedRow = 0
+	search.Header = []string{}
 }
 
 func (search *SearchMenu) Resize(termWidth, termHeight int) {
-	x1, y1 := termWidth/3, termHeight/4
-	x2, y2 := 2*termWidth/3, 3*termHeight/4
+	x1, y1 := termWidth/4, termHeight/4
+	x2, y2 := 3*termWidth/4, 3*termHeight/4
 	search.Table.SetRect(x1, y1, x2, y2)
 }
 
 func (search *SearchMenu) Draw(buf *ui.Buffer) {
 	search.Table.Title = " Search "
-	search.Table.Header = []string{" "}
+
 	if search.SymbolDoesNotExist {
 		search.Table.Header = []string{fmt.Sprintf(" Coin with symbol %s does not exist", search.SearchString)}
-	} else if len(search.SearchList) > 0 {
-		search.Table.Header = []string{fmt.Sprintf(" %v results", len(search.SearchList))}
+	} else if len(search.SearchData) > 0 {
+		search.Table.Header = []string{fmt.Sprintf(" %v results", len(search.SearchData))}
 	}
 
 	search.IsFull = !search.IsFull
@@ -73,8 +74,9 @@ func (search *SearchMenu) Draw(buf *ui.Buffer) {
 		suffix = FULL_BLOCK
 	}
 
-	input := [][]string{{fmt.Sprintf(" ~ %s%s", search.SearchString, suffix)}}
-	search.Table.Rows = append(input, search.SearchList...)
+	input := [][]string{{fmt.Sprintf(" ~ %s%s", search.SearchString, suffix), "", ""}, {"SYMBOL", "NAME", "PRICE"}}
+
+	search.Table.Rows = append(input, search.SearchData...)
 
 	search.Table.BorderStyle.Fg = ui.ColorCyan
 	search.Table.BorderStyle.Bg = ui.ColorClear
@@ -87,7 +89,7 @@ func (search *SearchMenu) Draw(buf *ui.Buffer) {
 	search.Table.RowStyle.Bg = ui.ColorClear
 	search.Table.ColResizer = func() {
 		x := search.Table.Inner.Dx()
-		search.Table.ColWidths = []int{x}
+		search.Table.ColWidths = []int{x / 4, x / 2, x / 4}
 	}
 	search.Table.Draw(buf)
 }

--- a/pkg/widgets/search.go
+++ b/pkg/widgets/search.go
@@ -1,0 +1,93 @@
+/*
+Copyright © 2021 Bhargav SNV bhargavsnv100@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package widgets
+
+import (
+	"fmt"
+
+	ui "github.com/gizak/termui/v3"
+)
+
+const (
+	FULL_BLOCK  = "█"
+	EMPTY_BLOCK = " "
+)
+
+type SearchMenu struct {
+	SearchString string
+	*Table
+	IsFull             bool
+	SymbolDoesNotExist bool
+	SearchList         [][]string
+}
+
+// NewSearchMenu is a constructor for the SearchMenu type
+func NewSearchMenu() *SearchMenu {
+	return &SearchMenu{
+		Table: NewTable(),
+	}
+}
+
+// Reset resets a search menu to its default values
+func (search *SearchMenu) Reset() {
+	search.SearchString = ""
+	search.SearchList = [][]string{}
+	search.IsFull = true
+	search.SymbolDoesNotExist = false
+	search.Table.SelectedRow = 0
+}
+
+func (search *SearchMenu) Resize(termWidth, termHeight int) {
+	x1, y1 := termWidth/3, termHeight/4
+	x2, y2 := 2*termWidth/3, 3*termHeight/4
+	search.Table.SetRect(x1, y1, x2, y2)
+}
+
+func (search *SearchMenu) Draw(buf *ui.Buffer) {
+	search.Table.Title = " Search "
+	search.Table.Header = []string{" "}
+	if search.SymbolDoesNotExist {
+		search.Table.Header = []string{fmt.Sprintf(" Coin with symbol %s does not exist", search.SearchString)}
+	} else if len(search.SearchList) > 0 {
+		search.Table.Header = []string{fmt.Sprintf(" %v results", len(search.SearchList))}
+	}
+
+	search.IsFull = !search.IsFull
+
+	suffix := EMPTY_BLOCK
+	if search.IsFull && len(search.SearchString) > 0 {
+		suffix = FULL_BLOCK
+	}
+
+	input := [][]string{{fmt.Sprintf(" ~ %s%s", search.SearchString, suffix)}}
+	search.Table.Rows = append(input, search.SearchList...)
+
+	search.Table.BorderStyle.Fg = ui.ColorCyan
+	search.Table.BorderStyle.Bg = ui.ColorClear
+
+	search.Table.RowStyle.Fg = ui.ColorCyan
+	if search.SymbolDoesNotExist {
+		search.Table.RowStyle.Fg = ui.ColorRed
+	}
+
+	search.Table.RowStyle.Bg = ui.ColorClear
+	search.Table.ColResizer = func() {
+		x := search.Table.Inner.Dx()
+		search.Table.ColWidths = []int{x}
+	}
+	search.Table.Draw(buf)
+}


### PR DESCRIPTION
### This draft-pr addresses #3 and adds the following:
- Opens basic search table on clicking `<C-s>`
- Naive text input option
- Shows a sorted list of symbols based on a searched string, if the string is a prefix of a key in `coinIDMap` and this symbol has a corresponding id for CoinGecko and CoinCap
- Allows the user to scroll through the list and select a symbol, on which it redirects to its coin page
- Shows basic error message on the incorrect query


### Todo
- [ ] Add query based on the full name of the coin
- [ ] Fix blinking "full" character bug ( only exists after one successful search and redirect )

### Comments

@Gituser143 Tell me if this implementation looks good, or if you something else in mind.
Also, for the search based on the name of the coin, is there a list of full names of coins pulled from the API? 