### PR TITLE
Switch docker image to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM golang:1.16
-
+FROM golang:1.16 as builder
 WORKDIR /app
-
 COPY . .
+RUN CGO_ENABLED=0 GOOS=linux \
+    go build --ldflags "-s -w" -a -o ./output/cryptgo ./cryptgo.go
 
-RUN go build ./cryptgo.go
+FROM alpine:latest
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
+COPY --from=builder /app/output/cryptgo /app/cryptgo
 
-ENTRYPOINT ["./cryptgo"]
+ENTRYPOINT ["/app/cryptgo"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Using Docker
 git clone https://github.com/Gituser143/cryptgo
 cd cryptgo
 docker build -t cryptgo .
-docker run -it -v "$HOME:/root" cryptgo
+docker run --rm -it -v "$HOME:/home/appuser" cryptgo
 ```
 
 From source:


### PR DESCRIPTION
**What's changed**

- Added build step
- Modified go build flags
  - Added ldflags to strip debugging information
  - Changed `goos` to linux
  - Disabled `cgo` at compile time
- Changed final image to `alpine`
- Added non privileged user

**Result:** 

- Docker image size went from `960MB` to `13.9MB`
- App no longer runs as root
- The image only contains the basic alpine components and the compiled static binary of cryptgo. 