### PR TITLE
fixed docker user volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN CGO_ENABLED=0 GOOS=linux \
 FROM alpine:latest
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser
+ENV HOME /home/appuser/
 COPY --from=builder /app/output/cryptgo /app/cryptgo
 
 ENTRYPOINT ["/app/cryptgo"]

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Replace `<version>` with a specific version for stable builds. Omitting `<:versi
 docker pull bhargavsnv/cryptgo:<version>
 
 # Run image
-docker run --rm -it -v "$HOME:/home/appuser" bhargavsnv/cryptgo
+docker run -u $(id -u ${USER}):$(id -g ${USER}) -v "$HOME:/home/appuser/" --rm -it bhargavsnv/cryptgo
 ```
 
 Optionally, an alias can be created for ease of use:
 
 ```bash
-alias cryptgo='docker run --rm -it -v "$HOME:/home/appuser" bhargavsnv/cryptgo'
+alias cryptgo='docker run -u $(id -u ${USER}):$(id -g ${USER}) -v "$HOME:/home/appuser/" --rm -it bhargavsnv/cryptgo'
 ```
 
 And run using:

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Replace `<version>` with a specific version for stable builds. Omitting `<:versi
 docker pull bhargavsnv/cryptgo:<version>
 
 # Run image
-docker run -u $(id -u ${USER}):$(id -g ${USER}) -v "$HOME:/home/appuser/" --rm -it bhargavsnv/cryptgo
+docker run -u $(id -u):$(id -g) -v "$HOME:/home/appuser/" --rm -it bhargavsnv/cryptgo
 ```
 
 Optionally, an alias can be created for ease of use:
 
 ```bash
-alias cryptgo='docker run -u $(id -u ${USER}):$(id -g ${USER}) -v "$HOME:/home/appuser/" --rm -it bhargavsnv/cryptgo'
+alias cryptgo='docker run -u $(id -u):$(id -g) -v "$HOME:/home/appuser/" --rm -it bhargavsnv/cryptgo'
 ```
 
 And run using:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cd cryptgo
 docker build -t cryptgo .
 
 # Run image
-docker run --rm -it -v "$HOME:/home/appuser" cryptgo
+docker run -u $(id -u):$(id -g) -v "$HOME:/home/appuser/" --rm -it bhargavsnv/cryptgo
 ```
 
 From source:


### PR DESCRIPTION
As mentioned in my [issue](https://github.com/Gituser143/cryptgo/issues/24), here is a fix for the docker volume permissions.
I have tried many things, but in order to keep the app working as a single binary, and to keep the container rootless, this is what I have come up with.

In the dockerfile I set the HOME env to the home folder of our default user.
In the run command I specified the -user flag so that the container runs with the user ID and group ID of the host system user. This way the app remains rootless, and GO recognizes and has write access to HOME.
I chose not to remove "appuser" as the default user from the dockerfile for two reasons: 1) We would need to create the home folder anyway and 2) this way if the end user runs the container WITHOUT specifying a user, the app still will not run as root, but default to appuser. (Ofcourse then their changes will not be saved.)

Fixes: #24 